### PR TITLE
Adding support to custom keypaths

### DIFF
--- a/Sculptor/SCLMantleResponseSerializer.h
+++ b/Sculptor/SCLMantleResponseSerializer.h
@@ -19,7 +19,9 @@ extern NSString * const SCLErrorDomain;
 @property (nonatomic, strong, readonly) id<SCLModelMatcher> modelMatcher;
 
 + (instancetype)serializerForModelClass:(Class)modelClass;
++ (instancetype)serializerForModelClass:(Class)modelClass keypath:(NSString *)keypath;
 
 + (instancetype)serializerWithModelMatcher:(id<SCLModelMatcher>)modelMatcher;
++ (instancetype)serializerWithModelMatcher:(id<SCLModelMatcher>)modelMatcher keypath:(NSString *)keypath;
 
 @end

--- a/Sculptor/SCLMantleResponseSerializer.m
+++ b/Sculptor/SCLMantleResponseSerializer.m
@@ -27,7 +27,7 @@ NSString * const SCLErrorDomain = @"SCLErrorDomain";
 + (instancetype)serializerForModelClass:(Class)modelClass keypath:(NSString *)keypath
 {
 	id<SCLModelMatcher> modelMatcher = [SCLStaticModelMatcher staticModelMatcher:modelClass];
-	return [self serializerWithModelMatcher:modelMatcher];
+	return [self serializerWithModelMatcher:modelMatcher keypath:keypath];
 }
 
 + (instancetype)serializerWithModelMatcher:(id<SCLModelMatcher>)modelMatcher

--- a/Sculptor/SCLMantleResponseSerializer.m
+++ b/Sculptor/SCLMantleResponseSerializer.m
@@ -14,11 +14,17 @@ NSString * const SCLErrorDomain = @"SCLErrorDomain";
 
 @interface SCLMantleResponseSerializer ()
 @property (nonatomic, strong, readwrite) id<SCLModelMatcher> modelMatcher;
+@property (nonatomic, copy) NSString *keypath;
 @end
 
 @implementation SCLMantleResponseSerializer
 
 + (instancetype)serializerForModelClass:(Class)modelClass
+{
+    return [self serializerForModelClass:modelClass keypath:nil];
+}
+
++ (instancetype)serializerForModelClass:(Class)modelClass keypath:(NSString *)keypath
 {
 	id<SCLModelMatcher> modelMatcher = [SCLStaticModelMatcher staticModelMatcher:modelClass];
 	return [self serializerWithModelMatcher:modelMatcher];
@@ -26,9 +32,15 @@ NSString * const SCLErrorDomain = @"SCLErrorDomain";
 
 + (instancetype)serializerWithModelMatcher:(id<SCLModelMatcher>)modelMatcher
 {
+    return [self serializerWithModelMatcher:modelMatcher keypath:nil];
+}
+
++ (instancetype)serializerWithModelMatcher:(id<SCLModelMatcher>)modelMatcher keypath:(NSString *)keypath
+{
 	NSParameterAssert(modelMatcher != nil);
 	SCLMantleResponseSerializer *responseSerializer = [self serializerWithReadingOptions:0];
 	responseSerializer.modelMatcher = modelMatcher;
+    responseSerializer.keypath = keypath;
 	return responseSerializer;
 }
 
@@ -55,6 +67,10 @@ NSString * const SCLErrorDomain = @"SCLErrorDomain";
 		return nil;
 	}
 
+    if (self.keypath) {
+        responseObject = [responseObject valueForKeyPath:self.keypath];
+    }
+    
 	NSValueTransformer *JSONTransformer = nil;
 	if ([responseObject isKindOfClass:[NSDictionary class]]) {
 		JSONTransformer = [NSValueTransformer mtl_JSONDictionaryTransformerWithModelClass:modelClass];


### PR DESCRIPTION
Sometimes, you have to navigate through the response JSON to get the model you really want. Now, it can be done by specifying a keypath when you create a serializer.
